### PR TITLE
Use systemd-growfs to increase rootfs on first boot

### DIFF
--- a/flasher/overlays/installer/usr/local/bin/installer.sh
+++ b/flasher/overlays/installer/usr/local/bin/installer.sh
@@ -103,6 +103,7 @@ BOOTFS_PART=$(lsblk -n -o PATH | grep "${CHOICE}" | grep -Fvx "${CHOICE}" | sed 
 ROOTFS_PART=$(lsblk -n -o PATH | grep "${CHOICE}" | grep -Fvx "${CHOICE}" | sed -n "${ROOTFS_PART_NO}p")
 
 # Regenerate btrfs fsid
+echo "Regenerating rootfs Filesystem UUID"
 ROOTFS_BLKID_OLD=$(blkid -s UUID -o value ${ROOTFS_PART})
 echo "Old blkid $ROOTFS_BLKID_OLD"
 btrfstune -m ${ROOTFS_PART}

--- a/flasher/overlays/installer/usr/local/bin/installer.sh
+++ b/flasher/overlays/installer/usr/local/bin/installer.sh
@@ -98,21 +98,9 @@ if [ ${BMAP_EXITCODE} != 0 ] ; then
   shutdown -h now
 fi
 
-# Fix GPT to take the full size
-sleep 10
-echo fix | parted ---pretend-input-tty ${CHOICE} print
-sync
-sleep 10
-
 ROOTFS_PART_NO=2
 BOOTFS_PART=$(lsblk -n -o PATH | grep "${CHOICE}" | grep -Fvx "${CHOICE}" | sed -n "1p")
 ROOTFS_PART=$(lsblk -n -o PATH | grep "${CHOICE}" | grep -Fvx "${CHOICE}" | sed -n "${ROOTFS_PART_NO}p")
-
-# Expand rootfs partition table
-echo "Expanding root partition ${ROOTFS_PART}"
-parted -s ${CHOICE} resizepart ${ROOTFS_PART_NO} 100%
-sync
-sleep 10
 
 # Regenerate btrfs fsid
 ROOTFS_BLKID_OLD=$(blkid -s UUID -o value ${ROOTFS_PART})
@@ -129,11 +117,6 @@ echo "New blkid $ROOTFS_BLKID_NEW"
 ROOTFS_MNT="/mnt/rootfs"
 mkdir -p ${ROOTFS_MNT}
 mount ${ROOTFS_PART} ${ROOTFS_MNT}
-
-# Expand rootfs
-btrfs filesystem resize max ${ROOTFS_MNT}
-sync
-sleep 10
 
 # Mount boot
 BOOTFS_MNT="${ROOTFS_MNT}/boot/efi"

--- a/overlays/systemd-repart/usr/lib/repart.d/50-root.conf
+++ b/overlays/systemd-repart/usr/lib/repart.d/50-root.conf
@@ -1,0 +1,2 @@
+[Partition]
+Type=root

--- a/resctl-demo-image-efiboot.yaml
+++ b/resctl-demo-image-efiboot.yaml
@@ -23,6 +23,7 @@ actions:
         options:
           - rw
           - discard=async
+          - x-systemd.growfs
       - mountpoint: /boot/efi
         partition: EFI
     partitions:
@@ -34,6 +35,8 @@ actions:
         end: 256M
         flags: [ boot ]
       - name: system
+        partlabel: system
+        parttype: 4f68bce3-e8cd-4db1-96e7-fbcaf984b709
         fs: btrfs
         start: 256M
         end: 100%

--- a/resctl-demo-ospack.yaml
+++ b/resctl-demo-ospack.yaml
@@ -235,6 +235,10 @@ actions:
     description: Configuration for systemd-resolved
     source: overlays/systemd-resolved
 
+  - action: overlay
+    description: Configuration for systemd-repart
+    source: overlays/systemd-repart
+
   - action: run
     description: Setup root user
     chroot: true

--- a/start-qemu-flasher-efi-meta.sh
+++ b/start-qemu-flasher-efi-meta.sh
@@ -5,8 +5,8 @@ ROOT1_IMG="resctl-demo-meta-flasher-efiboot-testroot1.img"
 ROOT2_IMG="resctl-demo-meta-flasher-efiboot-testroot2.img"
 
 # create a disk to install to
-qemu-img create -f qcow2 ${ROOT1_IMG} 50G
-qemu-img create -f qcow2 ${ROOT2_IMG} 50G
+qemu-img create -f qcow2 ${ROOT1_IMG} 512G
+qemu-img create -f qcow2 ${ROOT2_IMG} 512G
 
 qemu-system-x86_64 \
   -machine type=q35,accel=kvm \

--- a/start-qemu-flasher-efi.sh
+++ b/start-qemu-flasher-efi.sh
@@ -5,8 +5,8 @@ ROOT1_IMG="resctl-demo-flasher-efiboot-testroot1.img"
 ROOT2_IMG="resctl-demo-flasher-efiboot-testroot2.img"
 
 # create a disk to install to
-qemu-img create -f qcow2 ${ROOT1_IMG} 50G
-qemu-img create -f qcow2 ${ROOT2_IMG} 50G
+qemu-img create -f qcow2 ${ROOT1_IMG} 512G
+qemu-img create -f qcow2 ${ROOT2_IMG} 512G
 
 qemu-system-x86_64 \
   -machine type=q35,accel=kvm \


### PR DESCRIPTION
Currently the installer script is a bit flakey; especially on
some hardware with large disks. Get rid of the dependency on
parted etc by handling all of the disk/partition increasing
in the initial rootfs.