### PR TITLE
ospack: Fix missing package atop

### DIFF
--- a/resctl-demo-ospack.yaml
+++ b/resctl-demo-ospack.yaml
@@ -98,7 +98,7 @@ actions:
   - action: apt
     description: Useful userspace packages
     packages:
-      - atop
+      - htop
       - bc
       - bcc
       - curl


### PR DESCRIPTION
Due to Debian bug #1016937, atop has been removed from testing. This breaks our builds and as such we need to replace atop with another tool until the bug is fixed. Replace atop with htop and top to prevent the build failure.

Link: https://tracker.debian.org/news/1364873/atop-removed-from-testing/
Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>