### PR TITLE
overlays/resctl-demo: Improve start-resctl-bench script

### DIFF
--- a/overlays/resctl-demo/home/demo/start-resctl-bench
+++ b/overlays/resctl-demo/home/demo/start-resctl-bench
@@ -20,7 +20,7 @@ cleanup
 # make sure base dir perm matches what resctl-demo would create
 RD_DIR="/var/lib/resctl-demo"
 sudo mkdir -p ${RD_DIR}
-sudo chown root.sudo ${RD_DIR}
+sudo chown root:sudo ${RD_DIR}
 sudo chmod u+w,g+ws ${RD_DIR}
 
 echo "Starting resctl-bench..."
@@ -67,7 +67,11 @@ echo "Saving result to $RESULT_JSON"
 set -e
 
 # Create benchmark using resctl-bench & convert results to PDF/TXT
-sudo resctl-bench -r "$RESULT_JSON" run iocost-tune
+for ((i = 0; i < 10; i++)); do
+    if sudo resctl-bench -r "$RESULT_JSON" run iocost-tune; then
+        break
+    fi
+done
 sudo resctl-bench -r "$RESULT_JSON" format iocost-tune:pdf=$RESULT_PDF >/dev/null
 sudo resctl-bench -r "$RESULT_JSON" format | sudo tee "$RESULT_SUMMARY" >/dev/null
 


### PR DESCRIPTION
* chown no longer like '.' as the separator between user and group. Use the suggested ':' instead.

* Retry 10 times if resctl-bench fails so that we can benefit from the resuming capability. resctl-bench is currently more crashy than expected, so this should help quite a bit in actually producing bench results.