### PR TITLE
Remove package firmware-intelwimax

### DIFF
--- a/resctl-demo-image-efiboot.yaml
+++ b/resctl-demo-image-efiboot.yaml
@@ -60,7 +60,6 @@ actions:
       - network-manager
       - firmware-atheros
       - firmware-brcm80211
-      - firmware-intelwimax
       - firmware-iwlwifi
       - firmware-linux
       - firmware-realtek


### PR DESCRIPTION
The Intel WiMAX drivers are no longer in debian and as such breaks the image build pipeline. Remove the missing package from the image build.

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>