### PR TITLE
Add network-manager to image

### DIFF
--- a/resctl-demo-ospack.yaml
+++ b/resctl-demo-ospack.yaml
@@ -82,6 +82,8 @@ actions:
     packages:
       - iproute2
       - iputils-ping
+      - network-manager
+      - wpasupplicant
 
   - action: apt
     description: openssh-server


### PR DESCRIPTION
network-manager provides nmtui which can be used to configure network and upload benchmark results afterwards.
For wifi support wpasupplicant package also need to be pre-installed.

Tested on machine with efi image.