### PR TITLE
[WIP] Add script to upload benchmark result

### DIFF
--- a/overlays/resctl-demo/home/demo/result-upload.sh
+++ b/overlays/resctl-demo/home/demo/result-upload.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright © 2023 Collabora Ltd.
+# SPDX-License-Identifier: MIT
+
+if [[ $# -ne 2 ]]; then
+  echo >&2 " Error: Wrong number of arguments"
+  echo >&2 " result-upload.sh  <RESULT FILE>  <SERVER URL>"
+  exit 1
+fi
+
+RESULT_JSON=$1
+SERVER_URL=$2
+
+ping -c 1 -w 100 -q github.com >&/dev/null
+
+if ! [[ $? == 0 ]] ; then
+  nmtui
+  ping -c 1 -w 100 -q github.com >&/dev/null
+  if [[ $? == 0 ]] ; then
+    echo "Network connected"
+  else
+    echo >&2 "Network not connected"
+    exit 1
+  fi
+else
+  echo "system is online"
+fi
+
+echo "Upload benchmark result...."
+
+curl --upload-file "$RESULT_JSON" "$SERVER_URL"
+
+if [[ $? -ne  0 ]]; then
+  echo >&2 "Failed to upload benchmark result"
+else
+  echo "Successfully uploaded benchmark result"
+fi


### PR DESCRIPTION
This also allow to configure network so that result could be uploaded to provided server.

This is work in progress since I need more input on this The purpose of early upload
is to early detect various use cases/scenario for upload.

As of now this script simply allow to configure network and upload the result to provided fileserver.
Few queries:
- Where the result should be uploaded ?
- Should this script automatically create github issue in iocost-benchmark with link to uploaded result ?
- Any other recommendation to fine-tune the script ?