### PR TITLE
Dump logs information to disk/usb for debugging purpose

### DIFF
--- a/overlays/resctl-demo/home/demo/start-resctl-bench
+++ b/overlays/resctl-demo/home/demo/start-resctl-bench
@@ -2,10 +2,13 @@
 # Copyright © 2020 Collabora Ltd.
 # SPDX-License-Identifier: MIT
 OUTPUT_DIR="/mnt/results"
+LOG_DIR="$OUTPUT_DIR/logs"
+LOCKFILE="$LOG_DIR/resctl-bench.lk"
 
 function cleanup {
   sudo rm -f /var/lib/resctl-demo/bench.json
   sudo umount "$OUTPUT_DIR" >/dev/null 2>&1 || true
+  sudo rm -rf $LOCKFILE
 }
 
 # Add rust bin to the path
@@ -65,16 +68,40 @@ echo "Saving result to $RESULT_JSON"
 
 # Exit on error
 set -e
+sudo mkdir -p $LOG_DIR
+sudo touch ${LOCKFILE}
 
+(
+  echo "Running resctl $RESULT_JSON"
+  echo "Log(terminal, dmesg, journal) will be saved to ${LOG_DIR}"
+  sudo sh -c "echo ${BASHPID} > ${LOCKFILE}"
+
+  export LOG_DUMP_FILE=${LOG_DIR}/resctl_terminal2.log
 # Create benchmark using resctl-bench & convert results to PDF/TXT
-for ((i = 0; i < 10; i++)); do
-    if sudo resctl-bench -r "$RESULT_JSON" run iocost-tune; then
-        break
+  for ((i = 0; i < 10; i++)); do
+    if sudo --preserve-env resctl-bench -r "$RESULT_JSON" run iocost-tune; then
+      break
     fi
-done
-sudo resctl-bench -r "$RESULT_JSON" format iocost-tune:pdf=$RESULT_PDF >/dev/null
-sudo resctl-bench -r "$RESULT_JSON" format | sudo tee "$RESULT_SUMMARY" >/dev/null
+  done
 
-echo "resctl-bench finshed successfully!"
-echo "Results saved to USB stick as $MODEL/$FILENAME"
+  sudo rm -rf $LOCKFILE
+  sudo resctl-bench -r "$RESULT_JSON" format iocost-tune:pdf=$RESULT_PDF >/dev/null
+  sudo resctl-bench -r "$RESULT_JSON" format | sudo tee "$RESULT_SUMMARY" >/dev/null
+
+  echo "resctl-bench finshed successfully!"
+  echo "Results saved to USB stick as $MODEL/$FILENAME"
+) &
+
+(
+  while [[ -f "$LOCKFILE" ]]; do
+    if [[ -s $LOCKFILE ]]; then
+      sleep 1  # randomly choosen
+      sudo sh -c "dmesg > $LOG_DIR/resctl_kernel.log"
+      sudo sh -c "journalctl -b > $LOG_DIR/resctl_journal.log"
+    fi
+  done
+) &
+
+wait
+
 cleanup

--- a/overlays/resctl-demo/home/demo/start-resctl-bench
+++ b/overlays/resctl-demo/home/demo/start-resctl-bench
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 OUTPUT_DIR="/mnt/results"
 LOG_DIR="$OUTPUT_DIR/logs"
+LOG_FILE="$LOG_DIR/resctl-bench_trace.log"
 LOCKFILE="$LOG_DIR/resctl-bench.lk"
 
 function cleanup {
@@ -76,10 +77,9 @@ sudo touch ${LOCKFILE}
   echo "Log(terminal, dmesg, journal) will be saved to ${LOG_DIR}"
   sudo sh -c "echo ${BASHPID} > ${LOCKFILE}"
 
-  export LOG_DUMP_FILE=${LOG_DIR}/resctl_terminal2.log
 # Create benchmark using resctl-bench & convert results to PDF/TXT
   for ((i = 0; i < 10; i++)); do
-    if sudo --preserve-env resctl-bench -r "$RESULT_JSON" run iocost-tune; then
+    if sudo --preserve-env resctl-bench -r "$RESULT_JSON" --logfile=$LOG_FILE run iocost-tune; then
       break
     fi
   done
@@ -100,6 +100,8 @@ sudo touch ${LOCKFILE}
       sudo sh -c "journalctl -b > $LOG_DIR/resctl_journal.log"
     fi
   done
+  sudo tar -zcf resctl-benchmark.tar.gz $RD_DIR
+  sudo cp resctl-benchmark.tar.gz $LOG_DIR
 ) &
 
 wait


### PR DESCRIPTION
Now this script dump dmesg, journalctl and terminal log to disk which can be used for debugging purpose.