### PR TITLE
Provide option to boot into installed image.

### DIFF
--- a/resctl-demo-flasher-efiboot.yaml
+++ b/resctl-demo-flasher-efiboot.yaml
@@ -33,6 +33,7 @@ actions:
       - btrfs-progs
       - dialog
       - systemd-boot
+      - kexec-tools
       - systemd-boot-efi
 
   - action: run


### PR DESCRIPTION
Once resctl-demo installation is finished, a new dialog prompt will be launched giving option to either shutdown or boot into new OS.

This facility can be used with drive that aren't detected by certain firmware, so we can use flasher image to boot from that drive.