### PR TITLE
Use resctl-demo kernel for flasher image.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,7 @@ jobs:
       # efi flasher
       - name: Build ${{ matrix.variant }}-flasher-efiboot
         run: |
-          sudo debos --disable-fakemachine --artifactdir=out --template-var=variant:${{ matrix.variant }} resctl-demo-flasher-efiboot.yaml
+          sudo debos --disable-fakemachine --artifactdir=out --template-var=variant:${{ matrix.variant }} --template-var=kernel_branch:debs resctl-demo-flasher-efiboot.yaml
 
       - name: Publish ${{ matrix.variant }}-flasher-efiboot
         uses: actions/upload-artifact@v3

--- a/resctl-demo-flasher-efiboot.yaml
+++ b/resctl-demo-flasher-efiboot.yaml
@@ -4,6 +4,7 @@
 {{ $mirror := or .mirror "https://deb.debian.org/debian" }}
 {{ $suite := or .suite "bookworm" }}
 {{ $pack := or .pack "true" }}
+{{ $kernel_branch := or .kernel_branch "resctl-demo" }}
 
 architecture: amd64
 
@@ -26,7 +27,6 @@ actions:
     packages:
       - systemd-sysv
       - udev
-      - linux-image-amd64
       - bmap-tools
       - efibootmgr
       - parted
@@ -34,6 +34,42 @@ actions:
       - dialog
       - systemd-boot
       - systemd-boot-efi
+
+{{ if eq $kernel_branch "debs" }}
+  # Use the kernel package from the filesystem
+  - action: overlay
+    description: Copy kernel package
+    source: debs
+    destination: debs
+{{ else }}
+  # Download the kernel package from GitHub
+  - action: download
+    url: https://nightly.link/iocost-benchmark/resctl-demo-linux/workflows/ci.yaml/{{ $kernel_branch }}/resctl-demo-kernel.zip
+    name: kernel
+    unpack: true
+    compression: zip
+
+  - action: overlay
+    description: Copy kernel package
+    origin: kernel
+    destination: debs
+{{ end }}
+
+  - action: run
+    description: Inspect kernel packages
+    command: ls -la ${ROOTDIR}/debs
+
+  - action: run
+    description: Install kernel packages
+    chroot: true
+    command: rm debs/*dbg*.deb || true;
+             apt-get install --yes --allow-downgrades ./debs/*.deb &&
+             rm -rf /debs
+
+  - action: run
+    description: Mark custom packages as hold
+    chroot: true
+    command: apt-mark hold linux*
 
   - action: run
     description: Set hostname to {{ $variant }}


### PR DESCRIPTION
Now, flasher images also uses same kernel as present in image instead of using default debian kernel.