### PR TITLE
  Log dmesg output when boot partition detection fails

### DIFF
--- a/flasher/overlays/installer/usr/local/bin/installer.sh
+++ b/flasher/overlays/installer/usr/local/bin/installer.sh
@@ -129,9 +129,16 @@ done
 if [ -z "${BOOTFS_PART}" ]; then
   echo "No boot partition found on target device: ${CHOICE}"
   echo "> Listing parition information:"
+
+  # Generate debugging info.
+  FLASHER_STORAGE_RESULTS=/mnt/results
+  mkdir -p ${FLASHER_STORAGE_RESULTS}
+  mount PARTLABEL=results ${FLASHER_STORAGE_RESULTS}
   sfdisk -d ${CHOICE}
   # dump parititon table sector(i.e first) for debugging purpose.
-  hd ${CHOICE} -n 512 -s 0x0 > ${FLASHER_STORAGE_MNT}/parition_dump
+  hd ${CHOICE} -n 512 -s 0x0 > ${FLASHER_STORAGE_RESULTS}/parition_dump
+  # dump dmesg log.
+  dmesg > ${FLASHER_STORAGE_RESULTS}/dmesg_log
   bash
 fi
 

--- a/resctl-demo-flasher-efiboot.yaml
+++ b/resctl-demo-flasher-efiboot.yaml
@@ -37,6 +37,7 @@ actions:
       - systemd-boot
       - kexec-tools
       - systemd-boot-efi
+      - bsdextrautils # for hd binary
 
   - action: apt
     description: Additional debug packages


### PR DESCRIPTION
Results are saved to PARTLABEL=results partition.