### PR TITLE
Revert back to debian kernel and also avoid copying full data directory.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,7 +101,7 @@ jobs:
       # efi flasher
       - name: Build ${{ matrix.variant }}-flasher-efiboot
         run: |
-          sudo debos --disable-fakemachine --artifactdir=out --template-var=variant:${{ matrix.variant }} --template-var=version:"${{ steps.version.outputs.version }}" --template-var=kernel_branch:debs resctl-demo-flasher-efiboot.yaml
+          sudo debos --disable-fakemachine --artifactdir=out --template-var=variant:${{ matrix.variant }} --template-var=version:"${{ steps.version.outputs.version }}" resctl-demo-flasher-efiboot.yaml
 
       - name: Publish ${{ matrix.variant }}-flasher-efiboot
         uses: actions/upload-artifact@v4

--- a/overlays/resctl-demo/home/demo/start-resctl-bench
+++ b/overlays/resctl-demo/home/demo/start-resctl-bench
@@ -100,8 +100,7 @@ sudo touch ${LOCKFILE}
       sudo sh -c "journalctl -b > $LOG_DIR/resctl_journal.log"
     fi
   done
-  sudo tar -zcf resctl-benchmark.tar.gz $RD_DIR
-  sudo cp resctl-benchmark.tar.gz $LOG_DIR
+  sudo resctl-bench -r "${RESULT_JSON}" pack
 ) &
 
 wait

--- a/resctl-demo-flasher-efiboot.yaml
+++ b/resctl-demo-flasher-efiboot.yaml
@@ -4,7 +4,6 @@
 {{ $mirror := or .mirror "https://deb.debian.org/debian" }}
 {{ $suite := or .suite "bookworm" }}
 {{ $pack := or .pack "true" }}
-{{ $kernel_branch := or .kernel_branch "resctl-demo" }}
 {{ $version := or .version "local" }}
 
 architecture: amd64
@@ -28,6 +27,7 @@ actions:
     packages:
       - systemd-sysv
       - udev
+      - linux-image-amd64
       - bmap-tools
       - efibootmgr
       - parted
@@ -49,42 +49,6 @@ actions:
     description: Add version metadata to /etc/os-release
     command: |
       echo "IMAGE_VERSION={{ $version }}" >> ${ROOTDIR}/etc/os-release
-
-{{ if eq $kernel_branch "debs" }}
-  # Use the kernel package from the filesystem
-  - action: overlay
-    description: Copy kernel package
-    source: debs
-    destination: debs
-{{ else }}
-  # Download the kernel package from GitHub
-  - action: download
-    url: https://nightly.link/iocost-benchmark/resctl-demo-linux/workflows/ci.yaml/{{ $kernel_branch }}/resctl-demo-kernel.zip
-    name: kernel
-    unpack: true
-    compression: zip
-
-  - action: overlay
-    description: Copy kernel package
-    origin: kernel
-    destination: debs
-{{ end }}
-
-  - action: run
-    description: Inspect kernel packages
-    command: ls -la ${ROOTDIR}/debs
-
-  - action: run
-    description: Install kernel packages
-    chroot: true
-    command: rm debs/*dbg*.deb || true;
-             apt-get install --yes --allow-downgrades ./debs/*.deb &&
-             rm -rf /debs
-
-  - action: run
-    description: Mark custom packages as hold
-    chroot: true
-    command: apt-mark hold linux*
 
   - action: run
     description: Set hostname to {{ $variant }}


### PR DESCRIPTION
There are two commits:
1. Revert back to use stable debian kernel
2.  Don't copy whole report directory instead just output pack result