### PR TITLE
Keep scheduled workflows alive

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,3 +159,13 @@ jobs:
             out/${{ matrix.variant }}-image-legacyboot.img.gz
             out/version.txt
           if-no-files-found: error
+
+  # Keep workflow alive
+  # See https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#disabling-and-enabling-workflows
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1.2.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: Build resctl-demo images
 on:
   pull_request:
   push:
-  # Build at 04:00am every Monday
+  # Every Monday 01:00 UTC
   schedule:
-    - cron: "0 4 * * 1"
+    - cron: "0 1 * * 1"
   workflow_dispatch:
     inputs:
       resctl_demo_src:


### PR DESCRIPTION
The workflows time-out after 60 days of zero activity (e.g. no commits)
and have to be manually re-enabled. Add a step to automatically enable
the scheduled workflows.