### PR TITLE
Don't pick up kernel from debian backports

### DIFF
--- a/resctl-demo-image-efiboot.yaml
+++ b/resctl-demo-image-efiboot.yaml
@@ -63,14 +63,6 @@ actions:
       - linux-image-amd64
       - linux-headers-amd64
 
-  - action: run
-    description: Upgrade kernel to backports
-    chroot: true
-    command: |
-      echo "deb http://deb.debian.org/debian {{ $suite }}-backports main" > /etc/apt/sources.list.d/backports.list
-      apt-get update
-      apt-get install --yes -t {{ $suite }}-backports linux-image-amd64
-
   - action: apt
     description: Install useful packages for baremetal
     packages:


### PR DESCRIPTION
Stay with the kernel from debian bookworm for now, as fetching the backports kernel was making the resctl-demo image unable to boot with this issue:

```
Initramfs unpacking failed: invalid magic at start of compressed archive
```