### PR TITLE
images: use kernel from backports

### DIFF
--- a/overlays/kernel-backports/etc/apt/preferences.d/99-kernel-backports
+++ b/overlays/kernel-backports/etc/apt/preferences.d/99-kernel-backports
@@ -1,0 +1,3 @@
+Package: linux-*
+Pin: release n=SUITE-backports
+Pin-Priority: 900

--- a/resctl-demo-image-efiboot.yaml
+++ b/resctl-demo-image-efiboot.yaml
@@ -57,19 +57,29 @@ actions:
   - action: unpack
     file: {{ $ospack }}.tar.gz
 
+
+  - action: overlay
+    description: Prioritize kernel from backports
+    source: overlays/kernel-backports
+
+  - action: run
+    description: Fix suite name for backports
+    chroot: true
+    label: sed
+    command: sed -i 's/n=SUITE-/n={{ $suite }}-/g' /etc/apt/preferences.d/99-kernel-backports
+
+  - action: run
+    description: Add backports apt repo
+    chroot: true
+    command: |
+      echo "deb http://deb.debian.org/debian {{ $suite }}-backports main" > /etc/apt/sources.list.d/backports.list
+      apt-get update
+
   - action: apt
     description: Install kernel
     packages:
       - linux-image-amd64
       - linux-headers-amd64
-
-  - action: run
-    description: Upgrade kernel to backports
-    chroot: true
-    command: |
-      echo "deb http://deb.debian.org/debian {{ $suite }}-backports main" > /etc/apt/sources.list.d/backports.list
-      apt-get update
-      apt-get install --yes -t {{ $suite }}-backports linux-image-amd64
 
   - action: apt
     description: Install useful packages for baremetal

--- a/resctl-demo-image-legacyboot.yaml
+++ b/resctl-demo-image-legacyboot.yaml
@@ -45,19 +45,28 @@ actions:
   - action: unpack
     file: {{ $ospack }}.tar.gz
 
+  - action: overlay
+    description: Prioritize kernel from backports
+    source: overlays/kernel-backports
+
+  - action: run
+    description: Fix suite name for backports
+    chroot: true
+    label: sed
+    command: sed -i 's/n=SUITE-/n={{ $suite }}-/g' /etc/apt/preferences.d/99-kernel-backports
+
+  - action: run
+    description: Add backports apt repo
+    chroot: true
+    command: |
+      echo "deb http://deb.debian.org/debian {{ $suite }}-backports main" > /etc/apt/sources.list.d/backports.list
+      apt-get update
+
   - action: apt
     description: Install kernel
     packages:
       - linux-image-amd64
       - linux-headers-amd64
-
-  - action: run
-    description: Upgrade kernel to backports
-    chroot: true
-    command: |
-      echo "deb http://deb.debian.org/debian {{ $suite }}-backports main" > /etc/apt/sources.list.d/backports.list
-      apt-get update
-      apt-get install --yes -t {{ $suite }}-backports linux-image-amd64
 
   - action: overlay
     description: Copy {{ $ospack }}.tar.gz into image


### PR DESCRIPTION
Added the priority for kernel from backports.

Fixes https://github.com/iocost-benchmark/resctl-demo-image-recipe/issues/59